### PR TITLE
Add transaction filtering views and URL routing

### DIFF
--- a/Budget_Project/Budget_Application/models.py
+++ b/Budget_Project/Budget_Application/models.py
@@ -9,8 +9,9 @@ from django.db import models
 
 
 class DataTransaction(models.Model):
+    transaction_id = models.AutoField(primary_key=True)
     id_user = models.ForeignKey('Users', on_delete=models.CASCADE, db_column='id_user')
-    data_transaction = models.DateField()
+    transaction_date = models.DateField()
     income = models.FloatField(blank=True, null=True)
     expense = models.FloatField(blank=True, null=True)
     description = models.CharField(blank=True, null=True, max_length=255)

--- a/Budget_Project/Budget_Application/urls.py
+++ b/Budget_Project/Budget_Application/urls.py
@@ -1,0 +1,31 @@
+from django.urls import path
+from .views import (
+    AllUserTransactionsView,
+    AllUserExpensesView,
+    AllUserIncomesView,
+    AllUserTransactionsByDateRangeView,
+    AllTransactionsFromDateView,
+    AllTransactionsToDateView,
+    ExpensesFromDateView,
+    ExpensesToDateView,
+    IncomesFromDateView,
+    IncomesToDateView,
+    UserTransactionsByDateRangeView
+)
+
+
+urlpatterns = [
+    path('transactions/user/<int:user_id>/', AllUserTransactionsView.as_view(), name='all-user-transactions'),
+    path('transactions/user/<int:user_id>/expenses/', AllUserExpensesView.as_view(), name='all-user-expenses'),
+    path('transactions/user/<int:user_id>/incomes/', AllUserIncomesView.as_view(), name='all-user-incomes'),
+    path('transactions/user/<int:user_id>/<str:transaction_type>/by-date/',
+         UserTransactionsByDateRangeView.as_view(), name='user-transactions-by-daterange'),
+    path('transactions/user/<int:user_id>/date-range/', AllUserTransactionsByDateRangeView.as_view(),
+         name='all-user-transactions-date-range'),
+    path('transactions/user/<int:user_id>/from-date/', AllTransactionsFromDateView.as_view(), name='transactions-from-date'),
+    path('transactions/user/<int:user_id>/to-date/', AllTransactionsToDateView.as_view(), name='transactions-to-date'),
+    path('transactions/user/<int:user_id>/expenses/start-date/', ExpensesFromDateView.as_view(), name='expenses-from-date'),
+    path('transactions/user/<int:user_id>/expenses/end-date/', ExpensesToDateView.as_view(), name='expenses-to-date'),
+    path('transactions/user/<int:user_id>/incomes/start-date/', IncomesFromDateView.as_view(), name='incomes-from-date'),
+    path('transactions/user/<int:user_id>/incomes/end-date/', IncomesToDateView.as_view(), name='incomes-to-date'),
+]

--- a/Budget_Project/Budget_Application/views.py
+++ b/Budget_Project/Budget_Application/views.py
@@ -1,3 +1,370 @@
 from django.shortcuts import render
 
 # Create your views here.
+from django.http import JsonResponse
+from django.views import View
+from .models import DataTransaction
+from datetime import datetime
+
+
+class AllUserTransactionsView(View):
+    def get(self, request, user_id):
+        transactions = DataTransaction.objects.filter(id_user=user_id)
+
+        transactions_list = []
+        for transaction in transactions:
+            transactions_list.append({
+                'transaction_id': transaction.transaction_id,
+                'transaction_date': transaction.transaction_date,
+                'income': float(transaction.income) if transaction.income else None,
+                'expense': float(transaction.expense) if transaction.expense else None,
+                'description': transaction.description,
+                'category': transaction.category,
+                'transaction_type': transaction.transaction_type
+            })
+
+        return JsonResponse({'transactions': transactions_list}, safe=False)
+
+
+class AllUserExpensesView(View):
+    def get(self, request, user_id):
+        transactions = DataTransaction.objects.filter(
+            id_user=user_id,
+            expense__isnull=False
+        )
+
+        expenses_list = []
+        for transaction in transactions:
+            expenses_list.append({
+                'transaction_id': transaction.transaction_id,
+                'transaction_date': transaction.transaction_date,
+                'expense': float(transaction.expense),
+                'description': transaction.description,
+                'category': transaction.category,
+                'transaction_type': transaction.transaction_type
+            })
+
+        return JsonResponse({'expenses': expenses_list}, safe=False)
+
+
+class AllUserIncomesView(View):
+    def get(self, request, user_id):
+        transactions = DataTransaction.objects.filter(
+            id_user=user_id,
+            income__isnull=False
+        )
+
+        incomes_list = []
+        for transaction in transactions:
+            incomes_list.append({
+                'transaction_id': transaction.transaction_id,
+                'transaction_date': transaction.transaction_date,
+                'income': float(transaction.income),
+                'description': transaction.description,
+                'category': transaction.category,
+                'transaction_type': transaction.transaction_type
+            })
+
+        return JsonResponse({'incomes': incomes_list}, safe=False)
+
+
+class UserTransactionsByDateRangeView(View):
+    def get(self, request, user_id, transaction_type):
+        start_date = request.GET.get('start_date')
+        end_date = request.GET.get('end_date')
+
+        if not all([start_date, end_date]):
+            return JsonResponse({
+                'error': 'Wymagane parametry start_date i end_date w formacie YYYY-MM-DD'
+            }, status=400)
+
+        try:
+            start_date = datetime.strptime(start_date, '%Y-%m-%d').date()
+            end_date = datetime.strptime(end_date, '%Y-%m-%d').date()
+        except ValueError:
+            return JsonResponse({
+                'error': 'Nieprawidłowy format daty. Użyj formatu YYYY-MM-DD'
+            }, status=400)
+
+        filter_params = {
+            'id_user': user_id,
+            'transaction_date__gte': start_date,
+            'transaction_date__lte': end_date
+        }
+
+        if transaction_type == 'expenses':
+            filter_params['expense__isnull'] = False
+            amount_field = 'expense'
+        else:  # incomes
+            filter_params['income__isnull'] = False
+            amount_field = 'income'
+
+        transactions = DataTransaction.objects.filter(**filter_params)
+
+        transactions_list = []
+        for transaction in transactions:
+            transactions_list.append({
+                'transaction_id': transaction.transaction_id,
+                'transaction_date': transaction.transaction_date,
+                amount_field: float(getattr(transaction, amount_field)),
+                'description': transaction.description,
+                'category': transaction.category,
+                'transaction_type': transaction.transaction_type
+            })
+
+        return JsonResponse({transaction_type: transactions_list}, safe=False)
+
+
+class AllUserTransactionsByDateRangeView(View):
+    def get(self, request, user_id):
+        start_date = request.GET.get('start_date')
+        end_date = request.GET.get('end_date')
+
+        if not all([start_date, end_date]):
+            return JsonResponse({
+                'error': 'Wymagane parametry start_date i end_date'
+            }, status=400)
+
+        try:
+            start_date = datetime.strptime(start_date, '%Y-%m-%d').date()
+            end_date = datetime.strptime(end_date, '%Y-%m-%d').date()
+        except ValueError:
+            return JsonResponse({
+                'error': 'Nieprawidłowy format daty. Użyj formatu YYYY-MM-DD'
+            }, status=400)
+
+        transactions = DataTransaction.objects.filter(
+            id_user=user_id,
+            transaction_date__gte=start_date,
+            transaction_date__lte=end_date
+        )
+
+        transactions_list = []
+        for transaction in transactions:
+            transactions_list.append({
+                'transaction_id': transaction.transaction_id,
+                'transaction_date': transaction.transaction_date,
+                'income': float(transaction.income) if transaction.income else None,
+                'expense': float(transaction.expense) if transaction.expense else None,
+                'description': transaction.description,
+                'category': transaction.category,
+                'transaction_type': transaction.transaction_type
+            })
+
+        return JsonResponse({'transactions': transactions_list}, safe=False)
+
+
+class AllTransactionsFromDateView(View):
+    def get(self, request, user_id):
+        start_date = request.GET.get('start_date')
+
+        if not start_date:
+            return JsonResponse({
+                'error': 'Wymagany parametr start_date'
+            }, status=400)
+
+        try:
+            start_date = datetime.strptime(start_date, '%Y-%m-%d').date()
+        except ValueError:
+            return JsonResponse({
+                'error': 'Nieprawidłowy format daty. Użyj formatu YYYY-MM-DD'
+            }, status=400)
+
+        transactions = DataTransaction.objects.filter(
+            id_user=user_id,
+            transaction_date__gte=start_date
+        )
+
+        transactions_list = []
+        for transaction in transactions:
+            transactions_list.append({
+                'transaction_id': transaction.transaction_id,
+                'transaction_date': transaction.transaction_date,
+                'income': float(transaction.income) if transaction.income else None,
+                'expense': float(transaction.expense) if transaction.expense else None,
+                'description': transaction.description,
+                'category': transaction.category,
+                'transaction_type': transaction.transaction_type
+            })
+
+        return JsonResponse({'transactions': transactions_list}, safe=False)
+
+
+class AllTransactionsToDateView(View):
+    def get(self, request, user_id):
+        end_date = request.GET.get('end_date')
+
+        if not end_date:
+            return JsonResponse({
+                'error': 'Wymagany parametr end_date'
+            }, status=400)
+
+        try:
+            end_date = datetime.strptime(end_date, '%Y-%m-%d').date()
+        except ValueError:
+            return JsonResponse({
+                'error': 'Nieprawidłowy format daty. Użyj formatu YYYY-MM-DD'
+            }, status=400)
+
+        transactions = DataTransaction.objects.filter(
+            id_user=user_id,
+            transaction_date__lte=end_date
+        )
+
+        transactions_list = []
+        for transaction in transactions:
+            transactions_list.append({
+                'transaction_id': transaction.transaction_id,
+                'transaction_date': transaction.transaction_date,
+                'income': float(transaction.income) if transaction.income else None,
+                'expense': float(transaction.expense) if transaction.expense else None,
+                'description': transaction.description,
+                'category': transaction.category,
+                'transaction_type': transaction.transaction_type
+            })
+
+        return JsonResponse({'transactions': transactions_list}, safe=False)
+
+
+class ExpensesFromDateView(View):
+    def get(self, request, user_id):
+        start_date = request.GET.get('start_date')
+
+        if not start_date:
+            return JsonResponse({
+                'error': 'Wymagany parametr start_date'
+            }, status=400)
+
+        try:
+            start_date = datetime.strptime(start_date, '%Y-%m-%d').date()
+        except ValueError:
+            return JsonResponse({
+                'error': 'Nieprawidłowy format daty. Użyj formatu YYYY-MM-DD'
+            }, status=400)
+
+        transactions = DataTransaction.objects.filter(
+            id_user=user_id,
+            transaction_date__gte=start_date,
+            expense__isnull=False
+        )
+
+        expenses_list = []
+        for transaction in transactions:
+            expenses_list.append({
+                'transaction_id': transaction.transaction_id,
+                'transaction_date': transaction.transaction_date,
+                'expense': float(transaction.expense),
+                'description': transaction.description,
+                'category': transaction.category,
+                'transaction_type': transaction.transaction_type
+            })
+
+        return JsonResponse({'expenses': expenses_list}, safe=False)
+
+
+class ExpensesToDateView(View):
+    def get(self, request, user_id):
+        end_date = request.GET.get('end_date')
+
+        if not end_date:
+            return JsonResponse({
+                'error': 'Wymagany parametr end_date'
+            }, status=400)
+
+        try:
+            end_date = datetime.strptime(end_date, '%Y-%m-%d').date()
+        except ValueError:
+            return JsonResponse({
+                'error': 'Nieprawidłowy format daty. Użyj formatu YYYY-MM-DD'
+            }, status=400)
+
+        transactions = DataTransaction.objects.filter(
+            id_user=user_id,
+            transaction_date__lte=end_date,
+            expense__isnull=False
+        )
+
+        expenses_list = []
+        for transaction in transactions:
+            expenses_list.append({
+                'transaction_id': transaction.transaction_id,
+                'transaction_date': transaction.transaction_date,
+                'expense': float(transaction.expense),
+                'description': transaction.description,
+                'category': transaction.category,
+                'transaction_type': transaction.transaction_type
+            })
+
+        return JsonResponse({'expenses': expenses_list}, safe=False)
+
+
+class IncomesFromDateView(View):
+    def get(self, request, user_id):
+        start_date = request.GET.get('start_date')
+
+        if not start_date:
+            return JsonResponse({
+                'error': 'Wymagany parametr start_date'
+            }, status=400)
+
+        try:
+            start_date = datetime.strptime(start_date, '%Y-%m-%d').date()
+        except ValueError:
+            return JsonResponse({
+                'error': 'Nieprawidłowy format daty. Użyj formatu YYYY-MM-DD'
+            }, status=400)
+
+        transactions = DataTransaction.objects.filter(
+            id_user=user_id,
+            transaction_date__gte=start_date,
+            income__isnull=False
+        )
+
+        incomes_list = []
+        for transaction in transactions:
+            incomes_list.append({
+                'transaction_id': transaction.transaction_id,
+                'transaction_date': transaction.transaction_date,
+                'income': float(transaction.income),
+                'description': transaction.description,
+                'category': transaction.category,
+                'transaction_type': transaction.transaction_type
+            })
+
+        return JsonResponse({'incomes': incomes_list}, safe=False)
+
+
+class IncomesToDateView(View):
+    def get(self, request, user_id):
+        end_date = request.GET.get('end_date')
+
+        if not end_date:
+            return JsonResponse({
+                'error': 'Wymagany parametr end_date'
+            }, status=400)
+
+        try:
+            end_date = datetime.strptime(end_date, '%Y-%m-%d').date()
+        except ValueError:
+            return JsonResponse({
+                'error': 'Nieprawidłowy format daty. Użyj formatu YYYY-MM-DD'
+            }, status=400)
+
+        transactions = DataTransaction.objects.filter(
+            id_user=user_id,
+            transaction_date__lte=end_date,
+            income__isnull=False
+        )
+
+        incomes_list = []
+        for transaction in transactions:
+            incomes_list.append({
+                'transaction_id': transaction.transaction_id,
+                'transaction_date': transaction.transaction_date,
+                'income': float(transaction.income),
+                'description': transaction.description,
+                'category': transaction.category,
+                'transaction_type': transaction.transaction_type
+            })
+
+        return JsonResponse({'incomes': incomes_list}, safe=False)

--- a/Budget_Project/Budget_Project/urls.py
+++ b/Budget_Project/Budget_Project/urls.py
@@ -15,8 +15,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('budget/', include('Budget_Application.urls')),
 ]


### PR DESCRIPTION
Wprowadziłem widoki umożliwiające filtrowanie transakcji, przychodów i wydatków według użytkownika, zakresu dat oraz typu. Zaktualizowałem modele – dodałem pole `transaction_id` oraz zmieniłem nazwę pola `data_transaction `na `transaction_date`. Dodałem również nowe ścieżki URL obsługujące te endpointy w API.

Przykłady użycia ( w output czysty JSON, do wykorzystania później frontowo w templates):
1. /budget/transactions/user/1/expenses/start-date/?start_date=2024-06-06
2. /budget/transactions/user/1/
3. /budget/transactions/user/1/expenses/by-date/?start_date=2025-01-01&end_date=2025-05-05
4. /budget/transactions/user/1/date-range/?start_date=2025-01-01&end_date=2025-05-03
5. /budget/transactions/user/1/incomes/end-date/?end_date=2025-06-06
6. itd